### PR TITLE
Legacy edition 2.7

### DIFF
--- a/32bit/32bit-uninstallers/32beta-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32beta-UNINSTALL.sh
@@ -16,7 +16,7 @@ sudo rm -r -f /usr/share/applications/Firefox-Beta-32bit.desktop ;
 # Desktop icons
 sudo rm -r -f /etc/skel/Desktop/Firefox-Beta-32bit.desktop ;
 # Current desktop icons
-rm -r -f /home/$USER/Desktop/Firefox-Beta-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Beta-32bit.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/32bit/32bit-uninstallers/32beta-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32beta-UNINSTALL.sh
@@ -17,9 +17,10 @@ sudo rm -r -f /usr/share/applications/Firefox-Beta-32bit.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Beta-32bit.desktop ;
 # Current desktop icons
 sudo rm -r -f /home/*/Desktop/Firefox-Beta-32bit.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-beta*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-beta*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/32bit/32bit-uninstallers/32esr-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32esr-UNINSTALL.sh
@@ -17,9 +17,10 @@ sudo rm -r -f /usr/share/applications/Firefox-ESR-32bit.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-ESR-32bit.desktop ;
 # Current desktop shortcuts
 sudo rm -r -f /home/*/Desktop/Firefox-ESR-32bit.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-esr*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-esr*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/32bit/32bit-uninstallers/32esr-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32esr-UNINSTALL.sh
@@ -16,7 +16,7 @@ sudo rm -r -f /usr/share/applications/Firefox-ESR-32bit.desktop ;
 # Desktop shortcuts
 sudo rm -r -f /etc/skel/Desktop/Firefox-ESR-32bit.desktop ;
 # Current desktop shortcuts
-rm -r -f /home/$USER/Desktop/Firefox-ESR-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-ESR-32bit.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/32bit/32bit-uninstallers/32firefox-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32firefox-UNINSTALL.sh
@@ -17,9 +17,10 @@ sudo rm -r -f /usr/share/applications/Firefox-32bit.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-32bit.desktop ;
 # Current desktop shortcuts
 sudo rm -r -f /home/*/Desktop/Firefox-32bit.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-release*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-release*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/32bit/32bit-uninstallers/32firefox-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32firefox-UNINSTALL.sh
@@ -16,7 +16,7 @@ sudo rm -r -f /usr/share/applications/Firefox-32bit.desktop ;
 # Desktop shortcuts
 sudo rm -r -f /etc/skel/Desktop/Firefox-32bit.desktop ;
 # Current desktop shortcuts
-rm -r -f /home/$USER/Desktop/Firefox-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-32bit.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/32bit/32bit-uninstallers/32firefox-all-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32firefox-all-UNINSTALL.sh
@@ -38,14 +38,15 @@ sudo rm -r -f /etc/skel/Desktop/Firefox-Developer-Edition-32bit.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Nightly-32bit.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-ESR-32bit.desktop ;
 # Current deskop shortcuts
-rm -r -f /home/$USER/Desktop/Firefox-32bit.desktop ;
-rm -r -f /home/$USER/Desktop/Firefox-Beta-32bit.desktop ;
-rm -r -f /home/$USER/Desktop/Firefox-Developer-Edition-32bit.desktop ;
-rm -r -f /home/$USER/Desktop/Firefox-Nightly-32bit.desktop ;
-rm -r -f /home/$USER/Desktop/Firefox-ESR-32bit.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+sudo rm -r -f /home/*/Desktop/Firefox-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Beta-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Nightly-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-ESR-32bit.desktop ;
+# Cache files
+sudo rm -r -f /home/*/.cache/mozilla/firefox/ ;
+# Configuration and profile files.
+sudo rm -r -f /home/*/.mozilla/firefox/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/32bit/32bit-uninstallers/32firefox-all-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32firefox-all-UNINSTALL.sh
@@ -5,7 +5,7 @@ echo
  while true; do
     read -p "This will REMOVE ALL releases of Mozilla Firefox 32-bit on your computer.
     
-Firefox
+Mozilla Firefox
 Firefox Beta
 Firefox Developer Edition
 Firefox Nightly

--- a/32bit/32bit-uninstallers/32firefox-dev-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32firefox-dev-UNINSTALL.sh
@@ -17,9 +17,10 @@ sudo rm -r -f /usr/share/applications/Firefox-Developer-Edition-32bit.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Developer-Edition-32bit.desktop ;
 # Current desktop shortcuts
 sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition-32bit.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.dev-edition*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.dev-edition*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/32bit/32bit-uninstallers/32firefox-dev-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32firefox-dev-UNINSTALL.sh
@@ -16,7 +16,7 @@ sudo rm -r -f /usr/share/applications/Firefox-Developer-Edition-32bit.desktop ;
 # Desktop shortcuts
 sudo rm -r -f /etc/skel/Desktop/Firefox-Developer-Edition-32bit.desktop ;
 # Current desktop shortcuts
-rm -r -f /home/$USER/Desktop/Firefox-Developer-Edition-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition-32bit.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/32bit/32bit-uninstallers/32nightly-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32nightly-UNINSTALL.sh
@@ -16,7 +16,7 @@ sudo rm -r -f /usr/share/applications/Firefox-Nightly-32bit.desktop ;
 # Desktop shortcuts
 sudo rm -r -f /etc/skel/Desktop/Firefox-Nightly-32bit.desktop ;
 # Current shortcuts
-rm -r -f /home/$USER/Desktop/Firefox-Nightly-32bit.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Nightly-32bit.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/32bit/32bit-uninstallers/32nightly-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32nightly-UNINSTALL.sh
@@ -17,9 +17,10 @@ sudo rm -r -f /usr/share/applications/Firefox-Nightly-32bit.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Nightly-32bit.desktop ;
 # Current shortcuts
 sudo rm -r -f /home/*/Desktop/Firefox-Nightly-32bit.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-nightly*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-nightly*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/32bit/32bit-uninstallers/unsub32.sh
+++ b/32bit/32bit-uninstallers/unsub32.sh
@@ -5,13 +5,13 @@
 # That which is done, cannot be undone. Reinstalled, of course! But not undone.
 #
  PS3='Please enter your choice:' 
- options=("Firefox" "Firefox Beta" "Firefox Developer Edition" "Firefox Nightly" "Firefox Extended Support Release" "Remove ALL" "Quit")
+ options=("Mozilla Firefox" "Firefox Beta" "Firefox Developer Edition" "Firefox Nightly" "Firefox Extended Support Release" "Remove ALL" "Quit")
  while :
  do
  select opt in "${options[@]}"
  do
   case $opt in
-  "Firefox") clear; echo "Notice:"; chmod +x ./32bit/32bit-uninstallers/32firefox-UNINSTALL.sh; ./32bit/32bit-uninstallers/32firefox-UNINSTALL.sh; break ;;
+  "Mozilla Firefox") clear; echo "Notice:"; chmod +x ./32bit/32bit-uninstallers/32firefox-UNINSTALL.sh; ./32bit/32bit-uninstallers/32firefox-UNINSTALL.sh; break ;;
   "Firefox Beta") clear; echo "Notice:"; chmod +x ./32bit/32bit-uninstallers/32beta-UNINSTALL.sh; ./32bit/32bit-uninstallers/32beta-UNINSTALL.sh; break ;;
   "Firefox Developer Edition") clear; echo "Notice:"; chmod +x ./32bit/32bit-uninstallers/32firefox-dev-UNINSTALL.sh; ./32bit/32bit-uninstallers/32firefox-dev-UNINSTALL.sh; break ;;
   "Firefox Nightly") clear; echo "Notice:"; chmod +x ./32bit/32bit-uninstallers/32nightly-UNINSTALL.sh; ./32bit/32bit-uninstallers/32nightly-UNINSTALL.sh; break ;;

--- a/32bit/firefox-all32.sh
+++ b/32bit/firefox-all32.sh
@@ -9,7 +9,7 @@ echo
  while true; do
     read -p "This will install ALL releases of Mozilla Firefox 32-bit onto your computer.
     
-Firefox
+Mozilla Firefox
 Firefox Beta
 Firefox Developer Edition
 Firefox Nightly

--- a/32bit/sub32.sh
+++ b/32bit/sub32.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 #
-# This file to be used with Setup.sh
+# Firefox automatic install for Linux - This file to be used with Setup.sh
 #
  PS3='Please enter your choice:' 
- options=("Firefox" "Firefox Beta" "Firefox Developer Edition" "Firefox Nightly" "Firefox Extended Support Release" "Install ALL 32-bit editions" "Quit")
+ options=("Mozill Firefox" "Firefox Beta" "Firefox Developer Edition" "Firefox Nightly" "Firefox Extended Support Release" "Install ALL 32-bit editions" "Quit")
  while :
  do
  select opt in "${options[@]}"
  do
   case $opt in
-  "Firefox") clear; echo "You selected Firefox"; echo; echo; chmod +x ./32bit/FirefoxStable32.sh; ./32bit/FirefoxStable32.sh; break ;;
+  "Mozilla Firefox") clear; echo "You selected Mozilla Firefox"; echo; echo; chmod +x ./32bit/FirefoxStable32.sh; ./32bit/FirefoxStable32.sh; break ;;
   "Firefox Beta") clear; echo "You selected Firefox Beta"; echo; echo; chmod +x ./32bit/FirefoxBeta32.sh; ./32bit/FirefoxBeta32.sh; break ;;
   "Firefox Developer Edition") clear; echo "You selected Firefox Developer Edition"; echo; echo; chmod +x ./32bit/Firefox-Developer-Edition32.sh; ./32bit/Firefox-Developer-Edition32.sh; break ;;
   "Firefox Nightly") clear; echo "You selected Firefox Nightly"; echo; echo; chmod +x ./32bit/FirefoxNightly32.sh; ./32bit/FirefoxNightly32.sh; break ;;

--- a/64bit/FirefoxStable.sh
+++ b/64bit/FirefoxStable.sh
@@ -26,7 +26,7 @@ chmod +x Mozilla-Firefox.desktop ;
 sudo cp Mozilla-Firefox.desktop /usr/share/applications ;
 # Copies desktop icon to all user desktops and grants them ownership (it is their desktop after all).
 for destdir in /home/*/Desktop/; do
-    cp Firefox.desktop "$destdir" &&
+    cp Mozilla-Firefox.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Mozilla-Firefox.desktop"
 done
 echo -n;

--- a/64bit/FirefoxStable.sh
+++ b/64bit/FirefoxStable.sh
@@ -3,13 +3,13 @@
 # Installs Mozilla Firefox (stable release). To be used with Setup.sh
 #
 # Wait for download notice.
-echo; echo "Please wait. I am downloading the latest stable version of Firefox"; echo;
+echo; echo "Please wait. I am downloading the latest stable version of Mozilla Firefox"; echo;
 # 4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
 # Download.
 wget -O FirefoxStable.tar.bz2 "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64"; echo; echo;
 # Begin install notice.
-echo "Installing Firefox";
+echo "Installing Mozilla Firefox";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Extracts to install path
@@ -21,22 +21,22 @@ chmod +x ./64bit/fs64-icon.sh ; bash ./64bit/fs64-icon.sh ;
 # Give time for icon script to complete
 sleep 2;
 # Makes icon executable allowing it to run Firefox (which is also executable).
-chmod +x Firefox.desktop ;
+chmod +x Mozilla-Firefox.desktop ;
 # Adds icon to application menu (xfce, gnome, cinnamon, mate, deepin, etc...).
-sudo cp Firefox.desktop /usr/share/applications ;
+sudo cp Mozilla-Firefox.desktop /usr/share/applications ;
 # Copies desktop icon to all user desktops and grants them ownership (it is their desktop after all).
 for destdir in /home/*/Desktop/; do
     cp Firefox.desktop "$destdir" &&
-    chown --reference="$destdir" "$destdir/Firefox.desktop"
+    chown --reference="$destdir" "$destdir/Mozilla-Firefox.desktop"
 done
 echo -n;
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
-sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox.desktop /etc/skel/Desktop ;
+sudo mkdir -p /etc/skel/Desktop ; sudo cp Mozilla-Firefox.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
-rm FirefoxStable.tar.bz2 ; rm Firefox.desktop ;
+rm FirefoxStable.tar.bz2 ; rm Mozilla-Firefox.desktop ;
 # Exit notice.
 echo; echo; echo "Congratulations!";
-echo "Firefox is now installed onto your computer.";
-echo "Firefox will update itself.";
+echo "Mozilla Firefox is now installed onto your computer.";
+echo "Mozilla Firefox will update itself.";
 echo "Happy browsing."; echo ; echo ;
 exit 0

--- a/64bit/firefox-all.sh
+++ b/64bit/firefox-all.sh
@@ -3,13 +3,13 @@
 # This will install ALL 64-bit releases. To be used with Setup.sh
 #
 # Firefox automatic install for Linux - Legacy Edition
-# v2.5
+# v2.7
 #
 echo
  while true; do
     read -p "This will install ALL releases of Mozilla Firefox onto your computer.
 
-Firefox
+Mozilla Firefox
 Firefox Beta
 Firefox Developer Edition
 Firefox Nightly

--- a/64bit/fs64-icon.sh
+++ b/64bit/fs64-icon.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
-# This script uses echo to generate a icon shortcut file. - Firefox stable release
+# This script uses echo to generate a icon shortcut file. - Mozilla Firefox stable release
 #
 # Creating icon
 echo "[Desktop Entry]
-Name=Firefox
+Name=Mozilla Firefox
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب
 GenericName[ast]=Restolador Web
@@ -87,13 +87,13 @@ Comment[uk]=Перегляд сторінок Інтернету
 Comment[vi]=Để duyệt các trang web
 Comment[zh_CN]=浏览互联网
 Comment[zh_TW]=瀏覽網際網路
-Exec=/opt/firefox/firefox %u
+Exec=/opt/firefox/firefox  %u --class MozillaFirefox
 Icon=/opt/firefox/browser/chrome/icons/default/default128.png
 Terminal=false
 Type=Application
 MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
 StartupNotify=true
-StartupWMClass=Firefox
+StartupWMClass=MozillaFirefox
 Categories=Network;WebBrowser;
 Keywords=web;browser;internet;
 Actions=new-window;new-private-window;
@@ -204,7 +204,7 @@ Name[wo]=Palanteer bu bees
 Name[xh]=Ifestile entsha
 Name[zh_CN]=新建窗口
 Name[zh_TW]=開新視窗
-Exec=/opt/firefox/firefox --new-window %u
+Exec=/opt/firefox/firefox --new-window %u --class MozillaFirefox
 
 [Desktop Action new-private-window]
 Name=New Private Window
@@ -312,6 +312,6 @@ Name[wo]=Panlanteeru biir bu bees
 Name[xh]=Ifestile yangasese entsha
 Name[zh_CN]=新建隐私浏览窗口
 Name[zh_TW]=新增隱私視窗
-Exec=/opt/firefox/firefox --private-window %u" > Firefox.desktop ;
+Exec=/opt/firefox/firefox --private-window %u --class MozillaFirefox" > Mozilla-Firefox.desktop ;
 # Exit
 exit 0

--- a/64bit/sub64.sh
+++ b/64bit/sub64.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 #
-# This file to be used with Setup.sh
+# Firefox automatic install for Linux - This file to be used with Setup.sh
 #
  PS3='Please enter your choice:' 
- options=("Firefox" "Firefox Beta" "Firefox Developer Edition" "Firefox Nightly" "Firefox Extended Support Release" "Install ALL 64-bit editions" "Quit")
+ options=("Mozilla Firefox" "Firefox Beta" "Firefox Developer Edition" "Firefox Nightly" "Firefox Extended Support Release" "Install ALL 64-bit editions" "Quit")
  while :
  do
  select opt in "${options[@]}"
  do
   case $opt in
-  "Firefox") clear; echo "You selected Firefox"; echo; echo; chmod +x ./64bit/FirefoxStable.sh; ./64bit/FirefoxStable.sh; break ;;
+  "Mozilla Firefox") clear; echo "You selected Mozilla Firefox"; echo; echo; chmod +x ./64bit/FirefoxStable.sh; ./64bit/FirefoxStable.sh; break ;;
   "Firefox Beta") clear; echo "You selected Firefox Beta"; echo; echo; chmod +x ./64bit/FirefoxBeta.sh; ./64bit/FirefoxBeta.sh; break ;;
   "Firefox Developer Edition") clear; echo "You selected Firefox Developer Edition"; echo; echo; chmod +x ./64bit/Firefox-Developer-Edition.sh; ./64bit/Firefox-Developer-Edition.sh; break ;;
   "Firefox Nightly") clear; echo "You selected Firefox Nightly"; echo; echo; chmod +x ./64bit/FirefoxNightly.sh; ./64bit/FirefoxNightly.sh; break ;;

--- a/64bit/uninstallers/beta-UNINSTALL.sh
+++ b/64bit/uninstallers/beta-UNINSTALL.sh
@@ -18,9 +18,9 @@ sudo rm -r -f /etc/skel/Desktop/Firefox-Beta.desktop ;
 # Current shortcuts
 sudo rm -r -f /home/*/Desktop/Firefox-Beta.desktop ;
 # Uncomment if you wish to delete file cache.
-# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-beta/ ;
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-beta*/ ;
 # Uncomment if you wish to delete configuration and profile files.
-# sudo rm -r -f /home/*/.mozilla/firefox/*.default-beta/ ;
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-beta*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/64bit/uninstallers/beta-UNINSTALL.sh
+++ b/64bit/uninstallers/beta-UNINSTALL.sh
@@ -15,11 +15,12 @@ sudo rm -r -f  /opt/firefox-beta/ ;
 sudo rm -r -f /usr/share/applications/Firefox-Beta.desktop ;
 # Desktop shortcuts
 sudo rm -r -f /etc/skel/Desktop/Firefox-Beta.desktop ;
-# Current desktop shortcuts
-rm -r -f /home/$USER/Desktop/Firefox-Beta.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Current shortcuts
+sudo rm -r -f /home/*/Desktop/Firefox-Beta.desktop ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-beta/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-beta/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/64bit/uninstallers/esr-UNINSTALL.sh
+++ b/64bit/uninstallers/esr-UNINSTALL.sh
@@ -15,11 +15,12 @@ sudo rm -r -f  /opt/firefox-esr/ ;
 sudo rm -r -f /usr/share/applications/Firefox-ESR.desktop ;
 # Desktop shortcuts
 sudo rm -r -f /etc/skel/Desktop/Firefox-ESR.desktop ;
-# Current desktop shortcuts
-rm -r -f /home/$USER/Desktop/Firefox-ESR.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Current shortcuts
+sudo rm -r -f /home/*/Desktop/Firefox-ESR.desktop ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-esr*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-esr*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/64bit/uninstallers/firefox-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-UNINSTALL.sh
@@ -16,7 +16,7 @@ sudo rm -r -f /usr/share/applications/Mozilla-Firefox.desktop ;
 # Desktop shortcuts
 sudo rm -r -f /etc/skel/Desktop/Mozilla-Firefox.desktop ;
 # Current desktop shortcuts
-rm -r -f /home/$USER/Desktop/Mozilla-Firefox.desktop ;
+sudo rm -r -f /home/*/Desktop/Mozilla-Firefox.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/64bit/uninstallers/firefox-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-UNINSTALL.sh
@@ -12,11 +12,11 @@ sleep 3;
 # Installation
 sudo rm -r -f  /opt/firefox/ ;
 # Menu shortcuts
-sudo rm -r -f /usr/share/applications/Firefox.desktop ;
+sudo rm -r -f /usr/share/applications/Mozilla-Firefox.desktop ;
 # Desktop shortcuts
-sudo rm -r -f /etc/skel/Desktop/Firefox.desktop ;
+sudo rm -r -f /etc/skel/Desktop/Mozilla-Firefox.desktop ;
 # Current desktop shortcuts
-rm -r -f /home/$USER/Desktop/Firefox.desktop ;
+rm -r -f /home/$USER/Desktop/Mozilla-Firefox.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/64bit/uninstallers/firefox-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-UNINSTALL.sh
@@ -17,9 +17,10 @@ sudo rm -r -f /usr/share/applications/Mozilla-Firefox.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Mozilla-Firefox.desktop ;
 # Current desktop shortcuts
 sudo rm -r -f /home/*/Desktop/Mozilla-Firefox.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-release*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-release*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/64bit/uninstallers/firefox-all-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-all-UNINSTALL.sh
@@ -43,10 +43,10 @@ sudo rm -r -f /home/*/Desktop/Firefox-Beta.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-Nightly.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-ESR.desktop ;
-# Uncomment if you wish to delete all your cache files.
-# sudo rm -r -f /home/*/.cache/mozilla/firefox/ ;
-# Uncomment if you wish to delete your configuration and profile files.
-# sudo rm -r -f /home/*/.mozilla/firefox/ ;
+# Cache files
+sudo rm -r -f /home/*/.cache/mozilla/firefox/ ;
+# Configuration and profile files.
+sudo rm -r -f /home/*/.mozilla/firefox/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/64bit/uninstallers/firefox-all-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-all-UNINSTALL.sh
@@ -5,7 +5,7 @@ echo
  while true; do
     read -p "This will REMOVE ALL releases of Mozilla Firefox on your computer.
     
-Firefox
+Mozilla Firefox
 Firefox Beta
 Firefox Developer Edition
 Firefox Nightly
@@ -26,19 +26,19 @@ sudo rm -r -f /opt/firefox-developer-edition ;
 sudo rm -r -f /opt/firefox-nightly/ ;
 sudo rm -r -f /opt/firefox-esr/ ;
 # Menu shortcuts
-sudo rm -r -f /usr/share/applications/Firefox.desktop ;
+sudo rm -r -f /usr/share/applications/Mozilla-Firefox.desktop ;
 sudo rm -r -f /usr/share/applications/Firefox-Beta.desktop ;
 sudo rm -r -f /usr/share/applications/Firefox-Developer-Edition.desktop ;
 sudo rm -r -f /usr/share/applications/Firefox-Nightly.desktop ;
 sudo rm -r -f /usr/share/applications/Firefox-ESR.desktop ;
 # Destkop shortcuts
-sudo rm -r -f /etc/skel/Desktop/Firefox.desktop ;
+sudo rm -r -f /etc/skel/Desktop/Mozilla-Firefox.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Beta.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Developer-Edition.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Nightly.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-ESR.desktop ;
 # Current desktop shotcuts
-sudo rm -r -f /home/*/Desktop/Firefox.desktop ;
+sudo rm -r -f /home/*/Desktop/Mozilla-Firefox.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-Beta.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-Nightly.desktop ;

--- a/64bit/uninstallers/firefox-all-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-all-UNINSTALL.sh
@@ -38,14 +38,15 @@ sudo rm -r -f /etc/skel/Desktop/Firefox-Developer-Edition.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Nightly.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-ESR.desktop ;
 # Current desktop shotcuts
-rm -r -f /home/$USER/Desktop/Firefox.desktop ;
-rm -r -f /home/$USER/Desktop/Firefox-Beta.desktop ;
-rm -r -f /home/$USER/Desktop/Firefox-Developer-Edition.desktop ;
-rm -r -f /home/$USER/Desktop/Firefox-Nightly.desktop ;
-rm -r -f /home/$USER/Desktop/Firefox-ESR.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+sudo rm -r -f /home/*/Desktop/Firefox.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Beta.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Nightly.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-ESR.desktop ;
+#Uncomment if you wish to delete all your cache files.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/ ;
+# Uncomment if you wish to delete your configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/64bit/uninstallers/firefox-all-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-all-UNINSTALL.sh
@@ -43,7 +43,7 @@ sudo rm -r -f /home/*/Desktop/Firefox-Beta.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-Nightly.desktop ;
 sudo rm -r -f /home/*/Desktop/Firefox-ESR.desktop ;
-#Uncomment if you wish to delete all your cache files.
+# Uncomment if you wish to delete all your cache files.
 # sudo rm -r -f /home/*/.cache/mozilla/firefox/ ;
 # Uncomment if you wish to delete your configuration and profile files.
 # sudo rm -r -f /home/*/.mozilla/firefox/ ;

--- a/64bit/uninstallers/firefox-dev-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-dev-UNINSTALL.sh
@@ -16,7 +16,7 @@ sudo rm -r -f /usr/share/applications/Firefox-Developer-Edition.desktop ;
 # Desktop shotcuts
 sudo rm -r -f /etc/skel/Desktop/Firefox-Developer-Edition.desktop ;
 # Current shortcuts
-rm -r -f /home/$USER/Desktop/Firefox-Developer-Edition.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/64bit/uninstallers/firefox-dev-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-dev-UNINSTALL.sh
@@ -17,9 +17,10 @@ sudo rm -r -f /usr/share/applications/Firefox-Developer-Edition.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Developer-Edition.desktop ;
 # Current shortcuts
 sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.dev-edition*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.dev-edition*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/64bit/uninstallers/nightly-UNINSTALL.sh
+++ b/64bit/uninstallers/nightly-UNINSTALL.sh
@@ -17,9 +17,10 @@ sudo rm -r -f /usr/share/applications/Firefox-Nightly.desktop ;
 sudo rm -r -f /etc/skel/Desktop/Firefox-Nightly.desktop ;
 # Current desktop shotcuts
 sudo rm -r -f /home/*/Desktop/Firefox-Nightly.desktop ;
-# Uncomment if you wish to also delete your configuration and profile files.
-# rm -r -f /home/$USER/.mozilla/ ;
-# rm -r -f /home/$USER/.cache/mozilla/ ;
+# Uncomment if you wish to delete file cache.
+# sudo rm -r -f /home/*/.cache/mozilla/firefox/*.default-nightly*/ ;
+# Uncomment if you wish to delete configuration and profile files.
+# sudo rm -r -f /home/*/.mozilla/firefox/*.default-nightly*/ ;
 echo; echo; echo "Thank you for using Mozilla Firefox.";
 echo "Firefox has been deleted and uninstalled. Per your request.";
 echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo; break ;;

--- a/64bit/uninstallers/nightly-UNINSTALL.sh
+++ b/64bit/uninstallers/nightly-UNINSTALL.sh
@@ -16,7 +16,7 @@ sudo rm -r -f /usr/share/applications/Firefox-Nightly.desktop ;
 # Destkop shortcuts
 sudo rm -r -f /etc/skel/Desktop/Firefox-Nightly.desktop ;
 # Current desktop shotcuts
-rm -r -f /home/$USER/Desktop/Firefox-Nightly.desktop ;
+sudo rm -r -f /home/*/Desktop/Firefox-Nightly.desktop ;
 # Uncomment if you wish to also delete your configuration and profile files.
 # rm -r -f /home/$USER/.mozilla/ ;
 # rm -r -f /home/$USER/.cache/mozilla/ ;

--- a/64bit/uninstallers/unsub64.sh
+++ b/64bit/uninstallers/unsub64.sh
@@ -5,13 +5,13 @@
 # That which is done, cannot be undone. Reinstalled, of course! But not undone.
 #
  PS3='Please enter your choice:' 
- options=("Firefox" "Firefox Beta" "Firefox Developer Edition" "Firefox Nightly" "Firefox Extended Support Release" "Remove ALL" "Quit")
+ options=("Mozilla Firefox" "Firefox Beta" "Firefox Developer Edition" "Firefox Nightly" "Firefox Extended Support Release" "Remove ALL" "Quit")
  while :
  do
  select opt in "${options[@]}"
  do
   case $opt in
-  "Firefox") clear; echo "Notice:"; chmod +x ./64bit/uninstallers/firefox-UNINSTALL.sh; ./64bit/uninstallers/firefox-UNINSTALL.sh; break ;;
+  "Mozilla Firefox") clear; echo "Notice:"; chmod +x ./64bit/uninstallers/firefox-UNINSTALL.sh; ./64bit/uninstallers/firefox-UNINSTALL.sh; break ;;
   "Firefox Beta") clear; echo "Notice:"; chmod +x ./64bit/uninstallers/beta-UNINSTALL.sh; ./64bit/uninstallers/beta-UNINSTALL.sh; break ;;
   "Firefox Developer Edition") clear; echo "Notice:"; chmod +x ./64bit/uninstallers/firefox-dev-UNINSTALL.sh; ./64bit/uninstallers/firefox-dev-UNINSTALL.sh; break ;;
   "Firefox Nightly") clear; echo "Notice:"; chmod +x ./64bit/uninstallers/nightly-UNINSTALL.sh; ./64bit/uninstallers/nightly-UNINSTALL.sh; break ;;

--- a/Setup.sh
+++ b/Setup.sh
@@ -2,7 +2,7 @@
 #
 # Firefox automatic install for Linux
 #  Legacy Edition
-#   v2.5
+#   v2.7
 #
 clear;
 echo;

--- a/oem/firefox_stable.sh
+++ b/oem/firefox_stable.sh
@@ -15,18 +15,18 @@ chmod +x ./fs64-icon.sh ; bash ./fs64-icon.sh ;
 # Give time for icon script to complete
 sleep 2;
 # Makes icon executable allowing it to run Firefox (which is also executable).
-chmod +x Firefox.desktop ;
+chmod +x Mozilla-Firefox.desktop ;
 # Adds icon to application menu (xfce, gnome, cinnamon, mate, deepin, etc...).
-cp Firefox.desktop /usr/share/applications ;
+cp Mozilla-Firefox.desktop /usr/share/applications ;
 # Copies desktop icon to all user desktops and grants them ownership (it is their desktop after all).
 for destdir in /home/*/Desktop/; do
-    cp Firefox.desktop "$destdir" &&
-    chown --reference="$destdir" "$destdir/Firefox.desktop"
+    cp Mozilla-Firefox.desktop "$destdir" &&
+    chown --reference="$destdir" "$destdir/Mozilla-Firefox.desktop"
 done
 echo -n;
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
-mkdir -p /etc/skel/Desktop ; cp Firefox.desktop /etc/skel/Desktop ;
+mkdir -p /etc/skel/Desktop ; cp Mozilla-Firefox.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
-rm FirefoxStable.tar.bz2 ; rm Firefox.desktop ;
+rm FirefoxStable.tar.bz2 ; rm Mozilla-Firefox.desktop ;
 # Exit
 exit 0

--- a/oem/fs64-icon.sh
+++ b/oem/fs64-icon.sh
@@ -4,7 +4,7 @@
 #
 # Creating icon
 echo "[Desktop Entry]
-Name=Firefox
+Name=Mozilla Firefox
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب
 GenericName[ast]=Restolador Web
@@ -87,13 +87,13 @@ Comment[uk]=Перегляд сторінок Інтернету
 Comment[vi]=Để duyệt các trang web
 Comment[zh_CN]=浏览互联网
 Comment[zh_TW]=瀏覽網際網路
-Exec=/opt/firefox/firefox %u
+Exec=/opt/firefox/firefox  %u --class MozillaFirefox
 Icon=/opt/firefox/browser/chrome/icons/default/default128.png
 Terminal=false
 Type=Application
 MimeType=text/html;text/xml;application/xhtml+xml;application/vnd.mozilla.xul+xml;text/mml;x-scheme-handler/http;x-scheme-handler/https;
 StartupNotify=true
-StartupWMClass=Firefox
+StartupWMClass=MozillaFirefox
 Categories=Network;WebBrowser;
 Keywords=web;browser;internet;
 Actions=new-window;new-private-window;
@@ -204,7 +204,7 @@ Name[wo]=Palanteer bu bees
 Name[xh]=Ifestile entsha
 Name[zh_CN]=新建窗口
 Name[zh_TW]=開新視窗
-Exec=/opt/firefox/firefox --new-window %u
+Exec=/opt/firefox/firefox --new-window %u --class MozillaFirefox
 
 [Desktop Action new-private-window]
 Name=New Private Window
@@ -312,6 +312,6 @@ Name[wo]=Panlanteeru biir bu bees
 Name[xh]=Ifestile yangasese entsha
 Name[zh_CN]=新建隐私浏览窗口
 Name[zh_TW]=新增隱私視窗
-Exec=/opt/firefox/firefox --private-window %u" > Firefox.desktop ;
+Exec=/opt/firefox/firefox --private-window %u --class MozillaFirefox" > Mozilla-Firefox.desktop ;
 # Exit
 exit 0


### PR DESCRIPTION
Resolves a minor desktop shortcut issue if the user forgot to first remove any bundled copy of Firefox before installing the stock install. They can now be installed side-by-side and run together if you choose. 

The issue was both icons were named, "Firefox" and if your package manager updated the bundled copy, it would overwrite the icon. Then upon using that shortcut, you would be redirected to the bundled copy.  This issue only impacted Firefox stable (64-bit). The fix was as simple as renaming the icon shortcut Mozilla Firefox (keeping the icon names different). 