### PR TITLE
from echo to printf

### DIFF
--- a/32bit/32bit-uninstallers/32beta-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32beta-UNINSTALL.sh
@@ -21,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-Beta-32bit.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.default-beta*/ ;
 #
 # exit notice
-printf -- '%s\n' "" "" "" "Thank you for using Mozilla Firefox." \
-"Firefox has been deleted and uninstalled. Per your request." \
-"Really sorry to see you go. Hope to see you again real soon." "" ""
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+" Really sorry to see you go. Hope to see you again real soon." "" ""
 # exit
 exit 0

--- a/32bit/32bit-uninstallers/32firefox-dev-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32firefox-dev-UNINSTALL.sh
@@ -21,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition-32bit.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.dev-edition*/ ;
 #
 # exit notice
-printf -- '%s\n' "" "" "" "Thank you for using Mozilla Firefox." \
-"Firefox has been deleted and uninstalled. Per your request." \
-"Really sorry to see you go. Hope to see you again real soon." "" ""
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+" Really sorry to see you go. Hope to see you again real soon." "" ""
 # exit
 exit 0

--- a/32bit/32bit-uninstallers/32nightly-UNINSTALL.sh
+++ b/32bit/32bit-uninstallers/32nightly-UNINSTALL.sh
@@ -21,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-Nightly-32bit.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.default-nightly*/ ;
 #
 # exit notice
-printf -- '%s\n' "" "" "" "Thank you for using Mozilla Firefox." \
-"Firefox has been deleted and uninstalled. Per your request." \
-"Really sorry to see you go. Hope to see you again real soon." "" ""
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+" Really sorry to see you go. Hope to see you again real soon." "" ""
 # exit
 exit 0

--- a/32bit/Firefox-Developer-Edition32.sh
+++ b/32bit/Firefox-Developer-Edition32.sh
@@ -2,14 +2,16 @@
 #
 # Installs Mozilla Firefox (developer edition). To be used with Setup.sh
 #
-# Wait for download notice.
-echo "Please wait. I am downloading the latest version of Firefox Developer Edition"; echo;
-# 4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./32bit/error.sh;
+# Download notice.
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Developer Edition.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
-# Download.
-wget -O FirefoxDeveloperEdition32.tar.bz2 "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux"; echo; echo;
+# Download using wget with curl failback.
+wget -L -O "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux" >/dev/null || curl -L -o "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux" || /.error.sh ;
 # Begin install notice.
-echo "Installing Firefox Developer Edition";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Developer Edition.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -31,15 +33,15 @@ for destdir in /home/*/Desktop/; do
     cp Firefox-Developer-Edition-32bit.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Developer-Edition-32bit.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-Developer-Edition-32bit.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
 rm FirefoxDeveloperEdition32.tar.bz2 ; rm Firefox-Developer-Edition-32bit.desktop ;
 # Exit notice.
-echo; echo; echo "Congratulations!";
-echo "Firefox Developer Edition is now installed onto your computer.";
-echo "Firefox Developer Edition will update itself.";
-echo "Happy browsing."; echo; echo;
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Developer Edition is now installed onto your computer." \
+  " Mozilla Firefox Developer Edition will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/32bit/FirefoxBeta32.sh
+++ b/32bit/FirefoxBeta32.sh
@@ -2,14 +2,16 @@
 #
 # Installs Mozilla Firefox (beta release). To be used with Setup.sh
 #
-# Wait for download notice.
-echo "Please wait. I am downloading the latest version of Firefox Beta"; echo;
-# 4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./32bit/error.sh;
+# Download notice.
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Beta.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
-# Download.
-wget -O FirefoxBeta32.tar.bz2 "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux"; echo; echo;
+# Download using wget with curl failback.
+wget -L -O "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux" >/dev/null || curl -L -o "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux" || /.error.sh ;
 # Begin install notice.
-echo "Installing Firefox Beta"
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Beta.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -31,15 +33,15 @@ for destdir in /home/*/Desktop/; do
     cp Firefox-Beta-32bit.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Beta-32bit.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-Beta-32bit.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
 rm FirefoxBeta32.tar.bz2 ; rm Firefox-Beta-32bit.desktop ;
 # Exit notice.
-echo; echo; echo "Congratulations!";
-echo "Firefox Beta is now installed onto your computer.";
-echo "Firefox Beta will update itself.";
-echo "Happy browsing."; echo; echo;
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Beta is now installed onto your computer." \
+  " Mozilla Firefox Beta will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/32bit/FirefoxESR32.sh
+++ b/32bit/FirefoxESR32.sh
@@ -2,14 +2,16 @@
 #
 # Installs Mozilla Firefox (extended support release). To be used with Setup.sh
 #
-# Wait for download notice.
-echo "Please wait. I am downloading the latest version of Firefox ESR"; echo;
-# 4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./32bit/error.sh;
+# Download notice.
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Extended Support Release.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
-# Download
-wget -O FirefoxESR32.tar.bz2 "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux"; echo; echo;
+# Download using wget with curl failback.
+wget -L -O "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux" >/dev/null || curl -L -o "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux" || /.error.sh ;
 # Begin install notice.
-echo "Installing Firefox Extended Support Release";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Extended Support Release.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -37,9 +39,9 @@ sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-ESR-32bit.desktop /etc/skel/De
 # Removes the temporary files no longer needed.
 rm FirefoxESR32.tar.bz2 ; rm Firefox-ESR-32bit.desktop ;
 # Exit notice.
-echo; echo; echo "Congratulations!";
-echo "Firefox ESR is now installed onto your computer.";
-echo "Firefox Extended Support Release edition will update itself.";
-echo "Happy browsing."; echo; echo;
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Extended Support Release is now installed onto your computer." \
+  " Mozilla Firefox Extended Support Release will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/32bit/FirefoxESR32.sh
+++ b/32bit/FirefoxESR32.sh
@@ -33,7 +33,7 @@ for destdir in /home/*/Desktop/; do
     cp Firefox-ESR-32bit.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-ESR-32bit.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-ESR-32bit.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.

--- a/32bit/FirefoxNightly32.sh
+++ b/32bit/FirefoxNightly32.sh
@@ -2,14 +2,16 @@
 #
 # Installs Mozilla Firefox (nightly release). To be used with Setup.sh
 #
-# Wait for download notice.
-echo "Please wait. I am downloading the latest version of Firefox Nightly"; echo;
-# 4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./32bit/error.sh;
+# Download notice.
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Nightly.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
-# Download.
-wget -O FirefoxNightly32.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux"; echo; echo;
+# Download using wget with curl failback.
+wget -L -O "FirefoxNightly.tar.bz2" "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux" >/dev/null || curl -L -o "FirefoxNightly.tar.bz2" "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux" || /.error.sh ;
 # Begin install notice.
-echo "Installing Firefox Nightly";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Nightly.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -31,15 +33,15 @@ for destdir in /home/*/Desktop/; do
     cp Firefox-Nightly-32bit.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Nightly-32bit.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-Nightly-32bit.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
 rm FirefoxNightly32.tar.bz2 ; rm Firefox-Nightly-32bit.desktop ;
 # Exit notice.
-echo; echo; echo "Congratulations!";
-echo "Firefox Nightly is now installed onto your computer.";
-echo "Firefox Nightly Edition will update itself.";
-echo "Happy browsing."; echo; echo;
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Nightly is now installed onto your computer." \
+  " Mozilla Firefox Nightly will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/32bit/FirefoxStable32.sh
+++ b/32bit/FirefoxStable32.sh
@@ -5,13 +5,13 @@
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./32bit/error.sh;
 # Download notice.
-printf -- '\n\n%s\n\n\n\n' "Please wait. I am download the latest version of Mozilla Firefox.";
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am download the latest version of Mozilla Firefox.";
 #4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
 # Download using wget with curl failback.
 wget -L -O "FirefoxStable.tar.bz2" "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux" >/dev/null || curl -L -o "FirefoxStable.tar.bz2" "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux" || /.error.sh ;
 # Begin install notice.
-printf -- '\n\n\n%s\n\n' "Installing Mozilla Firefox";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Extracts to install path
@@ -37,9 +37,9 @@ sudo mkdir -p /etc/skel/Desktop ; sudo cp Mozilla-Firefox.desktop /etc/skel/Desk
 # Removes the temporary files no longer needed.
 rm FirefoxStable.tar.bz2 ; rm Mozilla-Firefox.desktop ;
 # Exit notice.
-printf -- '%s\n' "" "" "" "Congratulations!" \
-  "Mozilla Firefox is now installed onto your computer." \
-  "Mozilla Firefox will update itself." \
-  "Happy browsing." "" ""
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox is now installed onto your computer." \
+  " Mozilla Firefox will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/32bit/error.sh
+++ b/32bit/error.sh
@@ -3,14 +3,14 @@
 # ERROR message to display should CURL or WGET not be located or fail to download
 #
 # Error notice.
-printf -- '%s\n' "" "" "" "I am sorry. I cannot download from Mozilla." \
-  "It is remotely possible CURL or WGET is not available on your computer." \
-  "It is also possible your internet connection failed." \
-  "Please verify that either CURL or WGET is installed (either will work)." \
-  "If one of them is installed, please check your internet connection." \
-  "Or please contact your system administator for assistance." \
+printf -- '%s\n' "" "" "" " I am sorry. I cannot download from Mozilla." \
+  " It is remotely possible CURL or WGET is not available on your computer." \
+  " It is also possible your internet connection failed." \
+  " Please verify that either CURL or WGET is installed (either will work)." \
+  " If one of them is installed, please check your internet connection." \
+  " Or please contact your system administator for assistance." \
   " " " " \
-  "I am now exiting the install... Nothing has changed on your computer." "" ""
+  " I am now exiting the install... Nothing has changed on your computer." "" ""
 # error exit.
 exit 1
 #

--- a/32bit/firefox-all32.sh
+++ b/32bit/firefox-all32.sh
@@ -3,14 +3,13 @@
 # This will install ALL 32-bit releases. To be used with Setup.sh
 #
 # Firefox automatic install for Linux - Universal shell edition
-# v2.9.0
+# v2.9.0.3
 #
-echo "Now installing ALL editions. Please wait... "; 
+printf -- '\n\n%s\n\n\n\n' " Now installing ALL 32-bt editions of Mozilla Firefox. Please wait... ";
 # Give time for user to read notice.
-sleep 2;
+sleep 2; 
 # Visual spacing
-echo; 
-echo; 
+printf -- '\n\n\n%s\n\n' " ";
 # Firefox Stable
 chmod +x ./32bit/FirefoxStable32.sh; ./32bit/FirefoxStable32.sh; 
 # Firefox Beta
@@ -22,8 +21,9 @@ chmod +x ./32bit/FirefoxNightly32.sh; ./32bit/FirefoxNightly32.sh;
 # Firefox Extended Support Release
 chmod +x ./32bit/FirefoxESR32.sh; ./32bit/FirefoxESR32.sh;
 # Exit notice
-echo; echo; echo "ALL editions of Mozilla Firfox 32-bit have been installed."; 
-echo  "They ALL will update themselves. No additional action is required."; 
-echo; echo "Happy Browsing!"; echo; echo;
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " ALL editions of Mozilla Firfox 32-bit have been installed onto your computer." \
+  " They ALL will update themselves. No additional action is required." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/32bit/icon-beta32.sh
+++ b/32bit/icon-beta32.sh
@@ -2,7 +2,7 @@
 #
 # Firefox Beta release icon - 32bit
 # Creating icon.
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 # The file name should be different from the default 64-bit names (keeps compatibility so you can install both if you choose).
 Name=Firefox Beta 32bit
 #

--- a/32bit/icon-developer32.sh
+++ b/32bit/icon-developer32.sh
@@ -2,7 +2,7 @@
 #
 # Firefox Developer Edition release icon - 32bit
 # Creating icon.
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 # The file name should be different from the default 64-bit names (keeps compatibility so you can install both if you choose).
 Name=Firefox Developer Edition 32bit
 #

--- a/32bit/icon-extended32.sh
+++ b/32bit/icon-extended32.sh
@@ -2,7 +2,7 @@
 #
 # Firefox Extended Support Release (ESR) icon - 32bit
 # Creating icon.
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 # The file name should be different from the default 64-bit names (keeps compatibility so you can install both if you choose).
 Name=Firefox ESR 32bit
 #

--- a/32bit/icon-firefox32.sh
+++ b/32bit/icon-firefox32.sh
@@ -2,7 +2,7 @@
 #
 # Firefox stable release icon - 32bit
 # Creating icon.
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 # The file name should be different from the default 64-bit names (keeps compatibility so you can install both if you choose).
 Name=Firefox 32bit
 #

--- a/32bit/icon-nightly32.sh
+++ b/32bit/icon-nightly32.sh
@@ -2,7 +2,7 @@
 #
 # Firefox Nightly release icon - 32bit
 # Creating icon.
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 # The file name should be different from the default 64-bit names (keeps compatibility so you can install both if you choose).
 Name=Firefox Nightly 32bit
 #

--- a/32bit/sub-menu32.sh
+++ b/32bit/sub-menu32.sh
@@ -1,43 +1,44 @@
 #!/bin/sh
 #
 # Firefox automatic install for Linux
-#  Universal Shell Edition
-#   v2.9.0
+#   v2.9.0.3
 #
 # -- This file to be used with Setup.sh
 #
 while true :
 do
- echo;
- echo "   3 2 b i t - M E N U";
- echo;
- echo "1. Mozill Firefox";
- echo "2. Firefox Beta";
- echo "3. Firefox Developer Edition";
- echo "4. Firefox Nightly";
- echo "5. Firefox Extended Support Release";
- echo "6. Install ALL 32-bit editions";
- echo "7. Exit";
- echo;
- echo "Please enter option [1 - 7]";
+ printf -- '\n\n%s\n\n\n\n' " ";
+ printf -- '%s\n' "   6 4 b i t - M E N U" \
+ " " \
+ " 1. Mozill Firefox" \
+ " 2. Firefox Beta" \
+ " 3. Firefox Developer Edition" \
+ " 4. Firefox Nightly" \
+ " 5. Firefox Extended Support Release" \
+ " 6. Install ALL 64-bit editions" \
+ " 7. Exit" \
+ "" ""
+ printf " Please enter option [1 - 7]";
  read -r opt
  case $opt in
-  1) clear; echo; echo "You selected Mozilla Firefox"; echo; chmod +x ./32bit/FirefoxStable32.sh; ./32bit/FirefoxStable32.sh; break ;;
+  1) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Mozilla Firefox"; chmod +x ./32bit/FirefoxStable32.sh; ./32bit/FirefoxStable32.sh; break ;;
 
-  2) clear; echo; echo "You selected Firefox Beta"; echo; chmod +x ./32bit/FirefoxBeta32.sh; ./32bit/FirefoxBeta32.sh; break ;;
+  2) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Firefox Beta"; chmod +x ./32bit/FirefoxBeta32.sh; ./32bit/FirefoxBeta32.sh; break ;;
 
-  3) clear; echo; echo "You selected Firefox Developer Edition"; echo; chmod +x ./32bit/Firefox-Developer-Edition32.sh; ./32bit/Firefox-Developer-Edition32.sh; break ;;
+  3) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Firefox Developer Edition"; chmod +x ./32bit/Firefox-Developer-Edition32.sh; ./32bit/Firefox-Developer-Edition32.sh; break ;;
 
-  4) clear; echo; echo "You selected Firefox Nightly"; echo; chmod +x ./32bit/FirefoxNightly32.sh; ./32bit/FirefoxNightly32.sh; break ;;
+  4) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Firefox Nightly"; chmod +x ./32bit/FirefoxNightly32.sh; ./32bit/FirefoxNightly32.sh; break ;;
 
-  5) clear; echo; echo "You selected Firefox Extended Support Release"; echo; chmod +x ./32bit/FirefoxESR32.sh; ./32bit/FirefoxESR32.sh; break ;;
+  5) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Firefox Extended Support Release"; chmod +x ./32bit/FirefoxESR32.sh; ./32bit/FirefoxESR32.sh; break ;;
 
-  6) clear; echo; echo "You selected to install ALL 32-bit editions"; echo; chmod +x ./32bit/firefox-all32.sh; ./32bit/firefox-all32.sh; break ;;
+  6) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected to install ALL 32-bit editions"; chmod +x ./32bit/firefox-all32.sh; ./32bit/firefox-all32.sh; break ;;
 
-  7) clear; echo; echo "Goodbye, $USER"; echo; exit 1;;
+  7) clear; printf -- '\n\n\n%s\n\n\n\n' " Goodbye, $USER"; exit 1;;
 
-  *) echo "$opt is an invaild option. Please select option between 1-7 only";
-     echo "Press the [enter] key to continue. . .";
+  *) clear;
+     printf -- '\n\n%s\n' " $opt is an invaild option. Please select option between 1-7 only" \
+     " Press the [enter] key to continue. . ."
      read -r enterKey;
+     clear;
 esac
 done

--- a/64bit/Firefox-Developer-Edition.sh
+++ b/64bit/Firefox-Developer-Edition.sh
@@ -5,13 +5,13 @@
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./64bit/error.sh;
 # Download notice.
-printf -- '\n\n%s\n\n\n\n' "Please wait. I am downloading the latest version of Mozilla Firefox Developer Edition.";
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Developer Edition.";
 #4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
 # Download using wget with curl failback.
 wget -L -O "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64" || /.error.sh ;
 # Begin install notice.
-printf -- '\n\n\n%s\n\n' "Installing Mozilla Firefox Developer Edition.";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Developer Edition.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -39,9 +39,9 @@ sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-Developer-Edition.desktop /etc
 # Removes the temporary files no longer needed.
 rm FirefoxDeveloperEdition.tar.bz2 ; rm Firefox-Developer-Edition.desktop ;
 # Exit notice.
-printf -- '%s\n' "" "" "" "Congratulations!" \
-  "Mozilla Firefox Developer Edition is now installed onto your computer." \
-  "Mozilla Firefox Developer Edition will update itself." \
-  "Happy browsing." "" ""
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Developer Edition is now installed onto your computer." \
+  " Mozilla Firefox Developer Edition will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/64bit/FirefoxBeta.sh
+++ b/64bit/FirefoxBeta.sh
@@ -5,13 +5,13 @@
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./64bit/error.sh;
 # Download notice.
-printf -- '\n\n%s\n\n\n\n' "Please wait. I am downloading the latest version of Mozilla Firefox Beta.";
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Beta.";
 #4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
 # Download using wget with curl failback.
 wget -L -O "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64" || /.error.sh ;
 # Begin install notice.
-printf -- '\n\n\n%s\n\n' "Installing Mozilla Firefox Beta.";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Beta.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -39,9 +39,9 @@ sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-Beta.desktop /etc/skel/Desktop
 # Removes the temporary files no longer needed.
 rm FirefoxStable.tar.bz2 ; rm Firefox-Beta.desktop ;
 # Exit notice.
-printf -- '%s\n' "" "" "" "Congratulations!" \
-  "Mozilla Firefox Beta is now installed onto your computer." \
-  "Mozilla Firefox Beta will update itself." \
-  "Happy browsing." "" ""
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Beta is now installed onto your computer." \
+  " Mozilla Firefox Beta will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/64bit/FirefoxESR.sh
+++ b/64bit/FirefoxESR.sh
@@ -5,13 +5,13 @@
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./64bit/error.sh;
 # Download notice.
-printf -- '\n\n%s\n\n\n\n' "Please wait. I am downloading the latest version of Mozilla Firefox Extended Support Release.";
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Extended Support Release.";
 #4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
 # Download using wget with curl failback.
 wget -L -O "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" || /.error.sh ;
 # Begin install notice.
-printf -- '\n\n\n%s\n\n' "Installing Mozilla Firefox Extended Support Release.";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Extended Support Release.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -39,9 +39,9 @@ sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-ESR.desktop /etc/skel/Desktop 
 # Removes the temporary files no longer needed.
 rm FirefoxESR.tar.bz2 ; rm Firefox-ESR.desktop ;
 # Exit notice.
-printf -- '%s\n' "" "" "" "Congratulations!" \
-  "Mozilla Firefox Extended Support Release is now installed onto your computer." \
-  "Mozilla Firefox Extended Support Release will update itself." \
-  "Happy browsing." "" ""
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Extended Support Release is now installed onto your computer." \
+  " Mozilla Firefox Extended Support Release will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/64bit/FirefoxNightly.sh
+++ b/64bit/FirefoxNightly.sh
@@ -5,13 +5,13 @@
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./64bit/error.sh;
 # Download notice.
-printf -- '\n\n%s\n\n\n\n' "Please wait. I am downloading the latest version of Mozilla Firefox Nightly.";
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Nightly.";
 #4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
 # Download using wget with curl failback.
 wget -L -O "FirefoxNightly.tar.bz2" "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxNightly.tar.bz2" "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64" || /.error.sh ;
 # Begin install notice.
-printf -- '\n\n\n%s\n\n' "Installing Mozilla Firefox Nightly.";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Nightly.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -39,9 +39,9 @@ sudo mkdir -p /etc/skel/Desktop ; sudo cp Firefox-Nightly.desktop /etc/skel/Desk
 # Removes the temporary files no longer needed.
 rm FirefoxNightly.tar.bz2 ; rm Firefox-Nightly.desktop ;
 # Exit notice.
-printf -- '%s\n' "" "" "" "Congratulations!" \
-  "Mozilla Firefox Nightly is now installed onto your computer." \
-  "Mozilla Firefox Nightly will update itself." \
-  "Happy browsing." "" ""
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Nightly is now installed onto your computer." \
+  " Mozilla Firefox Nightly will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/64bit/FirefoxStable.sh
+++ b/64bit/FirefoxStable.sh
@@ -5,13 +5,13 @@
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./64bit/error.sh;
 # Download notice.
-printf -- '\n\n%s\n\n\n\n' "Please wait. I am download the latest version of Mozilla Firefox.";
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am download the latest version of Mozilla Firefox.";
 #4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
 sleep 4;
 # Download using wget with curl failback.
 wget -L -O "FirefoxStable.tar.bz2" "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxStable.tar.bz2" "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64" || /.error.sh ;
 # Begin install notice.
-printf -- '\n\n\n%s\n\n' "Installing Mozilla Firefox";
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 sudo mkdir -p -m 755 /opt ;
 # Extracts to install path
@@ -37,9 +37,9 @@ sudo mkdir -p /etc/skel/Desktop ; sudo cp Mozilla-Firefox.desktop /etc/skel/Desk
 # Removes the temporary files no longer needed.
 rm FirefoxStable.tar.bz2 ; rm Mozilla-Firefox.desktop ;
 # Exit notice.
-printf -- '%s\n' "" "" "" "Congratulations!" \
-  "Mozilla Firefox is now installed onto your computer." \
-  "Mozilla Firefox will update itself." \
-  "Happy browsing." "" ""
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox is now installed onto your computer." \
+  " Mozilla Firefox will update itself." \
+  " Happy browsing." "" ""
 # exit
 exit 0

--- a/64bit/error.sh
+++ b/64bit/error.sh
@@ -3,14 +3,14 @@
 # ERROR message to display should CURL or WGET not be located or fail to download
 #
 # Error notice.
-printf -- '%s\n' "" "" "" "I am sorry. I cannot download from Mozilla." \
-  "It is remotely possible CURL or WGET is not available on your computer." \
-  "It is also possible your internet connection failed." \
-  "Please verify that either CURL or WGET is installed (either will work)." \
-  "If one of them is installed, please check your internet connection." \
-  "Or please contact your system administator for assistance." \
+printf -- '%s\n' "" "" "" " I am sorry. I cannot download from Mozilla." \
+  " It is remotely possible CURL or WGET is not available on your computer." \
+  " It is also possible your internet connection failed." \
+  " Please verify that either CURL or WGET is installed (either will work)." \
+  " If one of them is installed, please check your internet connection." \
+  " Or please contact your system administator for assistance." \
   " " " " \
-  "I am now exiting the install... Nothing has changed on your computer." "" ""
+  " I am now exiting the install... Nothing has changed on your computer." "" ""
 # error exit.
 exit 1
 #

--- a/64bit/firefox-all.sh
+++ b/64bit/firefox-all.sh
@@ -5,7 +5,7 @@
 # Firefox automatic install for Linux - Universal shell edition
 # v2.9.0.3
 #
-printf -- '\n\n%s\n\n\n\n' "Now installing ALL editions of Mozilla Firefox. Please wait... ";
+printf -- '\n\n%s\n\n\n\n' " Now installing ALL editions of Mozilla Firefox. Please wait... ";
 # Give time for user to read notice.
 sleep 2; 
 # Visual spacing
@@ -21,9 +21,9 @@ chmod +x ./64bit/FirefoxNightly.sh; ./64bit/FirefoxNightly.sh;
 # Firefox Extended Support Release
 chmod +x ./64bit/FirefoxESR.sh; ./64bit/FirefoxESR.sh;
 # Exit notice
-printf -- '%s\n' "" "" "" "Congratulations!" \
-  "ALL editions of Mozilla Firfox have been installed onto your computer." \
-  "They ALL will update themselves. No additional action is required." \
-  "Happy browsing." "" ""
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " ALL editions of Mozilla Firfox have been installed onto your computer." \
+  " They ALL will update themselves. No additional action is required." \
+  " Happy browsing." "" ""
 # Exit
 exit 0

--- a/64bit/icon-beta64.sh
+++ b/64bit/icon-beta64.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Firefox Beta release
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Beta
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/64bit/icon-developer64.sh
+++ b/64bit/icon-developer64.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Firefox Developer Edition
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Developer Edition
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/64bit/icon-extended64.sh
+++ b/64bit/icon-extended64.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Firefox Extended Support Release
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox ESR
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/64bit/icon-firefox64.sh
+++ b/64bit/icon-firefox64.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Mozilla Firefox stable release
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Mozilla Firefox
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/64bit/icon-nightly64.sh
+++ b/64bit/icon-nightly64.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Firefox Nightly Release
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Nightly
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/64bit/uninstallers/beta-UNINSTALL.sh
+++ b/64bit/uninstallers/beta-UNINSTALL.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
+# Firefox Automatic Install for Linux -- Uninstall Firefox Beta 64-bit -- File can be used independently
+#
 # Uninstalling Firefox notice
-echo "Uninstalling Mozilla Firefox Beta release"; echo; echo;
+printf -- '\n\n%s\n\n\n\n' " Uninstalling Mozilla Firefox Beta ";
 # Small delay to give user time to read the above notice.
 sleep 3;
 # Installation
@@ -19,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-Beta.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.default-beta*/ ;
 #
 # exit notice
-echo; echo; echo "Thank you for using Mozilla Firefox.";
-echo "Firefox has been deleted and uninstalled. Per your request.";
-echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo;
+printf -- '%s\n' "" "" "" "Thank you for using Mozilla Firefox." \
+"Firefox has been deleted and uninstalled. Per your request." \
+"Really sorry to see you go. Hope to see you again real soon." "" ""
 # exit
 exit 0

--- a/64bit/uninstallers/beta-UNINSTALL.sh
+++ b/64bit/uninstallers/beta-UNINSTALL.sh
@@ -21,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-Beta.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.default-beta*/ ;
 #
 # exit notice
-printf -- '%s\n' "" "" "" "Thank you for using Mozilla Firefox." \
-"Firefox has been deleted and uninstalled. Per your request." \
-"Really sorry to see you go. Hope to see you again real soon." "" ""
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+" Really sorry to see you go. Hope to see you again real soon." "" ""
 # exit
 exit 0

--- a/64bit/uninstallers/esr-UNINSTALL.sh
+++ b/64bit/uninstallers/esr-UNINSTALL.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
+# Firefox Automatic Install for Linux -- Uninstall Firefox ESR -- File can be used independently.
+#
 # Uninstalling Firefox notice
-echo "Uninstalling Mozilla Firefox ESR edition"; echo; echo;
+printf -- '\n\n%s\n\n\n\n' " Uninstalling Mozilla Firefox ESR";
 # Small delay to give user time to read the above notice.
 sleep 3;
 # Installation
@@ -19,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-ESR.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.default-esr*/ ;
 #
 # exit notice
-echo; echo; echo "Thank you for using Mozilla Firefox.";
-echo "Firefox has been deleted and uninstalled. Per your request.";
-echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo;
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+" Really sorry to see you go. Hope to see you again real soon." "" ""
 #exit
 exit 0

--- a/64bit/uninstallers/firefox-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-UNINSTALL.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
+# Firefox Automatic Install for Linux -- Uninstall Firefox (stable) -- File can be used independently.
+#
 # Uninstalling Firefox notice
-echo "Uninstalling Mozilla Firefox stable release"; echo; echo;
+printf -- '\n\n%s\n\n\n\n' " Uninstalling Mozilla Firefox stable release";
 # Small delay to give user time to read the above notice.
 sleep 3;
 # Installation
@@ -19,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Mozilla-Firefox.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.default-release*/ ;
 #
 # exit notice
-echo; echo; echo "Thank you for using Mozilla Firefox.";
-echo "Firefox has been deleted and uninstalled. Per your request.";
-echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo;
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+"Really sorry to see you go. Hope to see you again real soon." "" ""
 # exit
 exit 0

--- a/64bit/uninstallers/firefox-all-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-all-UNINSTALL.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
+# Firefox Automatic Install for Linux -- Uninstall ALL 64-bit editions -- File can be used independently.
+#
 # Uninstalling Firefox notice
-echo "Uninstalling ALL editons of Mozilla Firefox (64 bit)"; echo; echo;
+printf -- '\n\n%s\n\n\n\n' " Uninstalling ALL releases of Mozilla Firefox 64-bit";
 # Small delay to give user time to read the above notice.
 sleep 3;
 # Installation
@@ -33,8 +35,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-ESR.desktop ;
 # Configuration and profile files.
 # sudo rm -r -f /home/*/.mozilla/firefox/ ;
 # Exit notice
-echo; echo; echo "Thank you for using Mozilla Firefox.";
-echo "Firefox has been deleted and uninstalled. Per your request.";
-echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo;
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+" Really sorry to see you go. Hope to see you again real soon." "" ""
 # Exit
 exit 0

--- a/64bit/uninstallers/firefox-dev-UNINSTALL.sh
+++ b/64bit/uninstallers/firefox-dev-UNINSTALL.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
+# Firefox Automatic Install for Linux -- Uninstall Firefox Developer Edition 64-bit -- File can be used independently
+#
 # Uninstalling Firefox notice
-echo "Uninstalling Mozilla Firefox Developer Edition release"; echo; echo;
+printf -- '\n\n%s\n\n\n\n' " Uninstalling Firefox Developer Edition";
 # Small delay to give user time to read the above notice.
 sleep 3;
 # Installation
@@ -19,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-Developer-Edition.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.dev-edition*/ ;
 #
 # exit notice
-echo; echo; echo "Thank you for using Mozilla Firefox.";
-echo "Firefox has been deleted and uninstalled. Per your request.";
-echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo;
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+" Really sorry to see you go. Hope to see you again real soon." "" ""
 # exit
 exit 0

--- a/64bit/uninstallers/nightly-UNINSTALL.sh
+++ b/64bit/uninstallers/nightly-UNINSTALL.sh
@@ -1,7 +1,9 @@
 #!/bin/sh
 #
+# Firefox Automatic Install for Linux -- Uninstall Firefox Nightly 64-bit -- File can be used independently
+#
 # Uninstalling Firefox notice
-echo "Uninstalling Firefox Nightly release"; echo; echo;
+printf -- '\n\n%s\n\n\n\n' " Uninstalling Firefox Nightly release";
 # Small delay to give user time to read the above notice.
 sleep 3;
 # Installation
@@ -19,8 +21,8 @@ sudo rm -r -f /home/*/Desktop/Firefox-Nightly.desktop ;
 # sudo rm -r -f /home/*/.mozilla/firefox/*.default-nightly*/ ;
 #
 # exit notice
-echo; echo; echo "Thank you for using Mozilla Firefox.";
-echo "Firefox has been deleted and uninstalled. Per your request.";
-echo "Really sorry to see you go. Hope to see you again real soon."; echo; echo;
+printf -- '%s\n' "" "" "" " Thank you for using Mozilla Firefox." \
+" Firefox has been deleted and uninstalled. Per your request." \
+" Really sorry to see you go. Hope to see you again real soon." "" ""
 # exit
 exit 0

--- a/64bit/uninstallers/uninstall-menu64.sh
+++ b/64bit/uninstallers/uninstall-menu64.sh
@@ -1,47 +1,53 @@
 #!/bin/sh
 #
 # Firefox automatic install for Linux
-#  Universal Shell Edition
-#   v2.9.0
+#   v2.9.0.3
 #
 # -- This file to be used with Setup.sh
 #
 # That which is done, cannot be undone. Reinstalled, of course! But not undone.
 while true :
 do
- echo;
- echo "   U N I N S T A L L - 6 4 b i t - M E N U";
- echo;
- echo "CAUTION - You are about to remove and delete";
- echo "          Mozilla Firefox from your computer!";
- echo;
- echo "1. Mozill Firefox";
- echo "2. Firefox Beta";
- echo "3. Firefox Developer Edition";
- echo "4. Firefox Nightly";
- echo "5. Firefox Extended Support Release";
- echo "6. Remove ALL 64-bit editions";
- echo "7. Exit";
- echo;
- echo "Please enter option [1 - 7]";
+printf -- '\n\n%s\n\n\n\n' " ";
+printf -- '%s\n' "   U N I N S T A L L - 6 4 b i t - M E N U" \
+" " \
+" CAUTION - You are about to remove and delete" \
+"           Mozilla Firefox from your computer!" \
+" " \
+" 1. Mozill Firefox" \
+" 2. Firefox Beta" \
+" 3. Firefox Developer Edition" \
+" 4. Firefox Nightly" \
+" 5. Firefox Extended Support Release" \
+" 6. Uninstall ALL 64-bit editions" \
+" " \
+" 7. Exit" \
+" " \
+" 66. PURGE - CAUTION: Will remove all 64-bit editions" \ "                     and all browser cache and configuration files for" \ "                     all copies of Mozilla Firefox for all users on your computer." \
+"" ""
+ printf " Please enter option [1 - 7]";
  read -r opt
  case $opt in
-  1) clear; echo; echo "You selected Mozilla Firefox"; echo; chmod +x ./64bit/uninstallers/firefox-UNINSTALL.sh; ./64bit/uninstallers/firefox-UNINSTALL.sh; break ;;
+  1) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Mozilla Firefox"; chmod +x ./64bit/uninstallers/firefox-UNINSTALL.sh; ./64bit/uninstallers/firefox-UNINSTALL.sh; break ;;
 
-  2) clear; echo; echo "You selected Firefox Beta"; echo; chmod +x ./64bit/uninstallers/beta-UNINSTALL.sh; ./64bit/uninstallers/beta-UNINSTALL.sh; break ;;
+  2) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Firefox Beta"; chmod +x ./64bit/uninstallers/beta-UNINSTALL.sh; ./64bit/uninstallers/beta-UNINSTALL.sh; break ;;
 
-  3) clear; echo; echo "You selected Firefox Developer Edition"; echo; chmod +x ./64bit/uninstallers/firefox-dev-UNINSTALL.sh; ./64bit/uninstallers/firefox-dev-UNINSTALL.sh; break ;;
+  3) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Firefox Developer Edition"; chmod +x ./64bit/uninstallers/firefox-dev-UNINSTALL.sh; ./64bit/uninstallers/firefox-dev-UNINSTALL.sh; break ;;
 
-  4) clear; echo; echo "You selected Firefox Nightly"; echo; chmod +x ./64bit/uninstallers/nightly-UNINSTALL.sh; ./64bit/uninstallers/nightly-UNINSTALL.sh; break ;;
+  4) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Firefox Nightly"; chmod +x ./64bit/uninstallers/nightly-UNINSTALL.sh; ./64bit/uninstallers/nightly-UNINSTALL.sh; break ;;
 
-  5) clear; echo; echo "You selected Firefox Extended Support Release"; echo; chmod +x ./64bit/uninstallers/esr-UNINSTALL.sh; ./64bit/uninstallers/esr-UNINSTALL.sh; break ;;
+  5) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected Firefox Extended Support Release"; chmod +x ./64bit/uninstallers/esr-UNINSTALL.sh; ./64bit/uninstallers/esr-UNINSTALL.sh; break ;;
 
-  6) clear; echo; echo "You selected to remove ALL 64-bit editions"; echo; chmod +x ./64bit/uninstallers/firefox-all-UNINSTALL.sh; ./64bit/uninstallers/firefox-all-UNINSTALL.sh; break ;;
+  6) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected to remove ALL 64-bit editions"; chmod +x ./64bit/uninstallers/firefox-all-UNINSTALL.sh; ./64bit/uninstallers/firefox-all-UNINSTALL.sh; break ;;
 
-  7) clear; echo; echo "Goodbye, $USER"; echo; exit 1;;
+  7) clear; printf -- '\n\n\n%s\n\n\n\n' " Goodbye, $USER"; exit 1;;
+  
+  66) clear; printf -- '\n\n\n%s\n\n\n\n' " Per your request, $USER. Execute Order 66."; chmod +x ./64bit/uninstallers/PURGE-64.sh; ./64bit/uninstallers/PURGE-64.sh; break ;;
 
-  *) echo "$opt is an invaild option. Please select option between 1-7 only";
-     echo "Press the [enter] key to continue. . .";
+  *) clear;
+     printf -- '\n\n%s\n' " $opt is an invaild option. Please select option between 1-7 only" \
+     " Press the [enter] key to continue. . ."
      read -r enterKey;
+     clear;
 esac
 done

--- a/Setup.sh
+++ b/Setup.sh
@@ -1,37 +1,38 @@
 #!/bin/sh
 #
 # Firefox automatic install for Linux
-#  Universal Shell Edition
-#   v2.9.0
+#   v2.9.0.3
 #
 while true :
 do
  clear;
- echo;
- echo "   M A I N - M E N U";
- echo;
- echo "1. Install 64-bit Firefox -- Recommended";
- echo "2. Install 32-bit Firefox -- legacy";
- echo "3. Uninstall 64-bit";
- echo "4. Uninstall 32-bit";
- echo "5. Exit";
- echo;
- echo "Please enter option [1 - 5]";
+ printf -- '\n\n%s\n\n\n\n' " ";
+ printf -- '%s\n' "   M A I N - M E N U" \
+ " " \
+ " 1. Install 64-bit Firefox -- Recommended" \
+ " 2. Install 32-bit Firefox -- legacy" \
+ " 3. Uninstall 64-bit" \
+ " 4. Uninstall 32-bit" \
+ " 5. Exit" \
+ "" ""
+ printf " Please enter option [1 - 5]";
  read -r opt
  case $opt in
-  1) clear; echo; echo "You selected to install Firefox 64-bit"; echo; chmod +x ./64bit/sub-menu64.sh; ./64bit/sub-menu64.sh; exit 0 ;;
+  1) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected to install Firefox 64-bit"; chmod +x ./64bit/sub-menu64.sh; ./64bit/sub-menu64.sh; exit 0 ;;
 
-  2) clear; echo; echo "You selected to install Firefox 32-bit"; echo; chmod +x ./32bit/sub-menu32.sh; ./32bit/sub-menu32.sh; exit 0 ;;
+  2) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected to install Firefox 32-bit"; chmod +x ./32bit/sub-menu32.sh; ./32bit/sub-menu32.sh; exit 0 ;;
 
-  3) clear; echo; echo "You selected to uninstall 64-bit"; echo; chmod +x ./64bit/uninstallers/uninstall-menu64.sh; ./64bit/uninstallers/uninstall-menu64.sh; exit 0 ;;
+  3) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected to uninstall 64-bit"; chmod +x ./64bit/uninstallers/uninstall-menu64.sh; ./64bit/uninstallers/uninstall-menu64.sh; exit 0 ;;
 
-  4) clear; echo; echo "You selected to uninstall 32-bit"; echo; chmod +x ./32bit/32bit-uninstallers/uninstall-menu32.sh; ./32bit/32bit-uninstallers/uninstall-menu32.sh; exit 0 ;;
+  4) clear; printf -- '\n\n\n%s\n\n\n\n' " You selected to uninstall 32-bit"; chmod +x ./32bit/32bit-uninstallers/uninstall-menu32.sh; ./32bit/32bit-uninstallers/uninstall-menu32.sh; exit 0 ;;
 
-  5) clear; echo; echo "Goodbye, $USER"; echo; exit 1;;
+  5) clear; printf -- '\n\n\n%s\n\n\n\n' " Goodbye, $USER"; exit 1;;
 
-  *) echo "$opt is an invaild option. Please select option between 1-5 only";
-     echo "Press the [enter] key to continue. . .";
+  *) clear;
+     printf -- '\n\n%s\n' " $opt is an invaild option. Please select option between 1-7 only" \
+     " Press the [enter] key to continue. . ."
      read -r enterKey;
+     clear;
 esac
 done
 # Other than removing all my little developer notes. Do you know a better way to improve this? Dare to speak up!

--- a/how-to-install.txt
+++ b/how-to-install.txt
@@ -1,7 +1,7 @@
 Requirements:
 
 # You will need to have access to SUDO. = For installation
-# You will also need WGET installed. = For the original Firefox download
+# You will also need CULR or WGET installed. = For the original Firefox download
 # Depending on your distro, you will also need TAR or UNTAR, or BZIP2 installed. = To decompress .tar.bz2 file
 
 All of which are usually pre-installed and configured in all 

--- a/oem/OEM.sh
+++ b/oem/OEM.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 #
-# Firefox automatic install for Linux - oem - silent install
+# Firefox automatic install for Linux - oem - silent instal
 #
 # This OEM file (oem.sh) is redundant. You do not absolutely need to use this file. 
 # The enclosed setup files (for example, firefox_nightly.sh) within the OEM folder (directory) can work 
-# independently alongside (with) their associated icon file (for example, nightly64-icon.sh).  
+# independently alongside (with) their associated icon file (for example, icon-nightly64.sh) and error.sh.  
 # However, to use this file anyways, uncomment what you need and save.
 #
 # When done comment out the text below.

--- a/oem/OEM.sh
+++ b/oem/OEM.sh
@@ -8,7 +8,7 @@
 # However, to use this file anyways, uncomment what you need and save.
 #
 # When done comment out the text below.
-echo "If you are currently seeing this TEXT, your developer has not configured Firefox automatic install for Linux correctly as they should have commended out this text.";
+printf " If you are currently seeing this TEXT, your developer has not configured Firefox automatic install for Linux correctly as they should have commended out this text.";
 # When done comment out the text above.
 #
 # Firefox

--- a/oem/OEM.sh
+++ b/oem/OEM.sh
@@ -4,7 +4,7 @@
 #
 # This OEM file (oem.sh) is redundant. You do not absolutely need to use this file. 
 # The enclosed setup files (for example, firefox_nightly.sh) within the OEM folder (directory) can work 
-# independently alongside (with) their associated icon file (for example, icon-nightly64.sh) and error.sh.  
+# independently alongside (with) their associated icon file (for example, icon-nightly64.sh) and the error.sh file.
 # However, to use this file anyways, uncomment what you need and save.
 #
 # When done comment out the text below.

--- a/oem/error.sh
+++ b/oem/error.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# ERROR message to display should CURL or WGET not be located or fail to download
+#
+# Error notice.
+printf -- '%s\n' "" "" "" " I am sorry. I cannot download from Mozilla." \
+  " It is remotely possible CURL or WGET is not available on your computer." \
+  " It is also possible your internet connection failed." \
+  " Please verify that either CURL or WGET is installed (either will work)." \
+  " If one of them is installed, please check your internet connection." \
+  " Or please contact your system administator for assistance." \
+  " " " " \
+  " I am now exiting the install... Nothing has changed on your computer." "" ""
+# error exit.
+exit 1

--- a/oem/extended64-icon.sh
+++ b/oem/extended64-icon.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Firefox Extended Support Release
 #
 # Creating icon
-echo "[Desktop Entry]
+print "[Desktop Entry]
 Name=Firefox ESR
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/oem/firefox_beta.sh
+++ b/oem/firefox_beta.sh
@@ -21,7 +21,7 @@ tar xjf FirefoxBeta.tar.bz2 -C /opt/firefox-beta/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /opt/firefox-beta/firefox/ ;
 # Start create icon script.
-chmod +x ./64bit/icon-beta64.sh ; bash ./64bit/icon-beta64.sh ;
+chmod +x ./icon-beta64.sh ; bash ./icon-beta64.sh ;
 # Give time for icon script to complete.
 sleep 2;
 # Makes icon executable allowing it to run Firefox (which is also executable).

--- a/oem/firefox_beta.sh
+++ b/oem/firefox_beta.sh
@@ -2,8 +2,16 @@
 #
 # Firefox Beta - oem - silent install
 #
-# Download.
-wget -O FirefoxBeta.tar.bz2 "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64";
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
+# Download notice.
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Beta.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+sleep 4;
+# Download using wget with curl failback.
+wget -L -O "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64" || /.error.sh ;
+# Begin install notice.
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Beta.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -13,7 +21,7 @@ tar xjf FirefoxBeta.tar.bz2 -C /opt/firefox-beta/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /opt/firefox-beta/firefox/ ;
 # Start create icon script.
-chmod +x ./beta64-icon.sh ; bash ./beta64-icon.sh ;
+chmod +x ./64bit/icon-beta64.sh ; bash ./64bit/icon-beta64.sh ;
 # Give time for icon script to complete.
 sleep 2;
 # Makes icon executable allowing it to run Firefox (which is also executable).
@@ -25,10 +33,15 @@ for destdir in /home/*/Desktop/; do
     cp Firefox-Beta.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Beta.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 mkdir -p /etc/skel/Desktop ; cp Firefox-Beta.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
-rm FirefoxBeta.tar.bz2 ; rm Firefox-Beta.desktop ;
-# Exit
+rm FirefoxStable.tar.bz2 ; rm Firefox-Beta.desktop ;
+# Exit notice.
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Beta is now installed onto your computer." \
+  " Mozilla Firefox Beta will update itself." \
+  " Happy browsing." "" ""
+# exit
 exit 0

--- a/oem/firefox_beta.sh
+++ b/oem/firefox_beta.sh
@@ -1,17 +1,17 @@
 #!/bin/sh
 #
-# Firefox Beta - oem - silent install
+# Firefox Beta - oem - silent install - To be used with error.sh
 #
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./error.sh;
 # Download notice.
-printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Beta.";
+# printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Beta.";
 #4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
-sleep 4;
+# sleep 4;
 # Download using wget with curl failback.
 wget -L -O "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64" || /.error.sh ;
 # Begin install notice.
-printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Beta.";
+# printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Beta.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -39,9 +39,9 @@ mkdir -p /etc/skel/Desktop ; cp Firefox-Beta.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
 rm FirefoxStable.tar.bz2 ; rm Firefox-Beta.desktop ;
 # Exit notice.
-printf -- '%s\n' "" "" "" " Congratulations!" \
-  " Mozilla Firefox Beta is now installed onto your computer." \
-  " Mozilla Firefox Beta will update itself." \
-  " Happy browsing." "" ""
+# printf -- '%s\n' "" "" "" " Congratulations!" \
+#  " Mozilla Firefox Beta is now installed onto your computer." \
+#  " Mozilla Firefox Beta will update itself." \
+#  " Happy browsing." "" ""
 # exit
 exit 0

--- a/oem/firefox_developer.sh
+++ b/oem/firefox_developer.sh
@@ -5,13 +5,13 @@
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./error.sh;
 # Download notice.
-printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Developer Edition.";
+# printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Developer Edition.";
 #4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
-sleep 4;
+# sleep 4;
 # Download using wget with curl failback.
 wget -L -O "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64" || /.error.sh ;
 # Begin install notice.
-printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Developer Edition.";
+# printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Developer Edition.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -39,9 +39,9 @@ mkdir -p /etc/skel/Desktop ; cp Firefox-Developer-Edition.desktop /etc/skel/Desk
 # Removes the temporary files no longer needed.
 rm FirefoxDeveloperEdition.tar.bz2 ; rm Firefox-Developer-Edition.desktop ;
 # Exit notice.
-printf -- '%s\n' "" "" "" " Congratulations!" \
-  " Mozilla Firefox Developer Edition is now installed onto your computer." \
-  " Mozilla Firefox Developer Edition will update itself." \
-  " Happy browsing." "" ""
+# printf -- '%s\n' "" "" "" " Congratulations!" \
+#  " Mozilla Firefox Developer Edition is now installed onto your computer." \
+#  " Mozilla Firefox Developer Edition will update itself." \
+#  " Happy browsing." "" ""
 # exit
 exit 0

--- a/oem/firefox_developer.sh
+++ b/oem/firefox_developer.sh
@@ -2,8 +2,16 @@
 #
 # Firefox Developer Edition - oem - silent install
 #
-# Download.
-wget -O FirefoxDeveloperEdition.tar.bz2 "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64";
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
+# Download notice.
+printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Developer Edition.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+sleep 4;
+# Download using wget with curl failback.
+wget -L -O "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64" || /.error.sh ;
+# Begin install notice.
+printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Developer Edition.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -13,7 +21,7 @@ tar xjf FirefoxDeveloperEdition.tar.bz2 -C /opt/firefox-developer-edition/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /opt/firefox-developer-edition/firefox/ ;
 # Start create icon script.
-chmod +x ./developer64-icon.sh ; bash ./developer64-icon.sh ;
+chmod +x ./icon-developer64.sh ; bash ./icon-developer64.sh ;
 # Give time for icon script to complete.
 sleep 2;
 # Makes icon executable allowing it to run Firefox (which is also executable).
@@ -25,10 +33,15 @@ for destdir in /home/*/Desktop/; do
     cp Firefox-Developer-Edition.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Developer-Edition.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 mkdir -p /etc/skel/Desktop ; cp Firefox-Developer-Edition.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
 rm FirefoxDeveloperEdition.tar.bz2 ; rm Firefox-Developer-Edition.desktop ;
-# Exit
+# Exit notice.
+printf -- '%s\n' "" "" "" " Congratulations!" \
+  " Mozilla Firefox Developer Edition is now installed onto your computer." \
+  " Mozilla Firefox Developer Edition will update itself." \
+  " Happy browsing." "" ""
+# exit
 exit 0

--- a/oem/firefox_esr.sh
+++ b/oem/firefox_esr.sh
@@ -2,8 +2,16 @@
 #
 # Firefox ESR (Extended Support Release) - oem - silent install
 #
-# Download
-wget -O FirefoxESR.tar.bz2 "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64";
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
+# Download notice.
+# printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Extended Support Release.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+# sleep 4;
+# Download using wget with curl failback.
+wget -L -O "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" || /.error.sh ;
+# Begin install notice.
+# printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Extended Support Release.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -13,7 +21,7 @@ tar xjf FirefoxESR.tar.bz2 -C /opt/firefox-esr/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /opt/firefox-esr/firefox/ ;
 # Start create icon script.
-chmod +x ./extended64-icon.sh ; bash ./extended64-icon.sh ;
+chmod +x ./icon-extended64.sh ; bash ./icon-extended64.sh ;
 # Give time for icon script to complete.
 sleep 2;
 # Makes icon executable allowing it to run Firefox (which is also executable).
@@ -25,10 +33,15 @@ for destdir in /home/*/Desktop/; do
     cp Firefox-ESR.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-ESR.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 mkdir -p /etc/skel/Desktop ; cp Firefox-ESR.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
 rm FirefoxESR.tar.bz2 ; rm Firefox-ESR.desktop ;
-# Exit
+# Exit notice.
+# printf -- '%s\n' "" "" "" " Congratulations!" \
+#  " Mozilla Firefox Extended Support Release is now installed onto your computer." \
+#  " Mozilla Firefox Extended Support Release will update itself." \
+#  " Happy browsing." "" ""
+# exit
 exit 0

--- a/oem/firefox_nightly.sh
+++ b/oem/firefox_nightly.sh
@@ -2,8 +2,16 @@
 #
 # Firefox Nightly - oem - silent install
 #
-# Download.
-wget -O FirefoxNightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64";
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
+# Download notice.
+# printf -- '\n\n%s\n\n\n\n' " Please wait. I am downloading the latest version of Mozilla Firefox Nightly.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+# sleep 4;
+# Download using wget with curl failback.
+wget -L -O "FirefoxNightly.tar.bz2" "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxNightly.tar.bz2" "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64" || /.error.sh ;
+# Begin install notice.
+# printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox Nightly.";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /opt ;
 # Path where to be installed.
@@ -13,7 +21,7 @@ tar xjf FirefoxNightly.tar.bz2 -C /opt/firefox-nightly/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /opt/firefox-nightly/firefox/ ;
 # Start create icon script.
-chmod +x ./nightly64-icon.sh ; bash ./nightly64-icon.sh ;
+chmod +x ./icon-nightly64.sh ; bash ./icon-nightly64.sh ;
 # Give time for icon script to complete.
 sleep 2;
 # Makes icon executable allowing it to run Firefox (which is also executable).
@@ -25,10 +33,15 @@ for destdir in /home/*/Desktop/; do
     cp Firefox-Nightly.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Nightly.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 mkdir -p /etc/skel/Desktop ; cp Firefox-Nightly.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
 rm FirefoxNightly.tar.bz2 ; rm Firefox-Nightly.desktop ;
-# Exit
+# Exit notice.
+# printf -- '%s\n' "" "" "" " Congratulations!" \
+#  " Mozilla Firefox Nightly is now installed onto your computer." \
+#  " Mozilla Firefox Nightly will update itself." \
+#  " Happy browsing." "" ""
+# exit
 exit 0

--- a/oem/firefox_stable.sh
+++ b/oem/firefox_stable.sh
@@ -2,8 +2,16 @@
 #
 # Firefox (current stable edition) - oem - silent install
 #
-# Download.
-wget -O FirefoxStable.tar.bz2 "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64";
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
+# Download notice.
+# printf -- '\n\n%s\n\n\n\n' " Please wait. I am download the latest version of Mozilla Firefox.";
+#4-second wait before beginning download. Gives user time to read the above sentence and understand what is happening.
+# sleep 4;
+# Download using wget with curl failback.
+wget -L -O "FirefoxStable.tar.bz2" "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxStable.tar.bz2" "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64" || /.error.sh ;
+# Begin install notice.
+# printf -- '\n\n\n%s\n\n' " Installing Mozilla Firefox";
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /opt ;
 # Extracts to install path
@@ -11,7 +19,7 @@ tar xjf FirefoxStable.tar.bz2 -C /opt/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /opt/firefox/ ;
 # Start create icon script
-chmod +x ./firefox64-icon.sh ; bash ./firefox64-icon.sh ;
+chmod +x ./icon-firefox64.sh ; bash ./icon-firefox64.sh ;
 # Give time for icon script to complete
 sleep 2;
 # Makes icon executable allowing it to run Firefox (which is also executable).
@@ -23,10 +31,15 @@ for destdir in /home/*/Desktop/; do
     cp Mozilla-Firefox.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Mozilla-Firefox.desktop"
 done
-echo -n;
+printf "\n";
 # Adds a desktop icon to all FUTURE new login users (assuming you make any).
 mkdir -p /etc/skel/Desktop ; cp Mozilla-Firefox.desktop /etc/skel/Desktop ;
 # Removes the temporary files no longer needed.
 rm FirefoxStable.tar.bz2 ; rm Mozilla-Firefox.desktop ;
-# Exit
+# Exit notice.
+# printf -- '%s\n' "" "" "" " Congratulations!" \
+#  " Mozilla Firefox is now installed onto your computer." \
+#  " Mozilla Firefox will update itself." \
+#  " Happy browsing." "" ""
+# exit
 exit 0

--- a/oem/icon-beta64.sh
+++ b/oem/icon-beta64.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
-# This script uses echo to generate a icon shortcut file. - Firefox Beta release
+# This script uses echo to generate a icon shortcut file. - Firefox Beta release - File can work independently.
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Beta
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/oem/icon-developer64.sh
+++ b/oem/icon-developer64.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 #
-# This script uses echo to generate a icon shortcut file. - Firefox Developer Edition
+# This script uses echo to generate a icon shortcut file. - Firefox Developer Edition - File can work independently.
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Developer Edition
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/oem/icon-extended64.sh
+++ b/oem/icon-extended64.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Firefox Extended Support Release
 #
 # Creating icon
-print "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox ESR
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/oem/icon-firefox64.sh
+++ b/oem/icon-firefox64.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Firefox stable release
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Mozilla Firefox
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/oem/icon-nightly64.sh
+++ b/oem/icon-nightly64.sh
@@ -3,7 +3,7 @@
 # This script uses echo to generate a icon shortcut file. - Firefox Nightly Release
 #
 # Creating icon
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Nightly
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب

--- a/personal/Install.sh
+++ b/personal/Install.sh
@@ -4,7 +4,7 @@
 #
 # This Install file (Install.sh) is redundant. You do not absolutely need to use this file. 
 # The enclosed setup files (for example, nightly.sh which installs Firefox Nightly) 
-# within the "personal" folder (directory) can work independently.  
+# within the "personal" folder (directory) can work independently along with the error.sh file.  
 # However, to use this file anyways, uncomment what you need and save.
 # By default this file is set to install the latest stable edition of Mozilla Firefox.
 #

--- a/personal/beta.sh
+++ b/personal/beta.sh
@@ -2,8 +2,10 @@
 #
 # Firefox Beta - personal - silent install
 #
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
 # Download.
-wget -O FirefoxBeta.tar.bz2 "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64";
+wget -L -O "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxBeta.tar.bz2" "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64" || /.error.sh ;
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /home/$USER/Mozilla ;
 # Path where to be installed.
@@ -13,7 +15,7 @@ tar xjf FirefoxBeta.tar.bz2 -C /home/$USER/Mozilla/firefox-beta/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /home/$USER/Mozilla/firefox-beta/firefox/ ;
 # Create icon script using echo command
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Beta
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب
@@ -334,7 +336,7 @@ for destdir in /home/$USER/Desktop/; do
     cp Firefox-Beta.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Beta.desktop"
 done
-echo -n;
+printf "\n";
 # Removes the temporary files no longer needed.
 rm FirefoxBeta.tar.bz2 ; rm Firefox-Beta.desktop ;
 # Exit

--- a/personal/developer.sh
+++ b/personal/developer.sh
@@ -2,8 +2,10 @@
 #
 # Firefox Developer Edition - personal - silent install
 #
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh
 # Download.
-wget -O FirefoxDeveloperEdition.tar.bz2 "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64";
+wget -L -O "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxDeveloperEdition.tar.bz2" "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64" || /.error.sh ;
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /home/$USER/Mozilla ;
 # Path where to be installed.
@@ -13,7 +15,7 @@ tar xjf FirefoxDeveloperEdition.tar.bz2 -C /home/$USER/Mozilla/firefox-developer
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /home/$USER/Mozilla/firefox-developer-edition/firefox/ ;
 # Create icon script using echo command
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Developer Edition
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب
@@ -334,7 +336,7 @@ for destdir in /home/$USER/Desktop/; do
     cp Firefox-Developer-Edition.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Developer-Edition.desktop"
 done
-echo -n;
+printf "\n";
 # Removes the temporary files no longer needed.
 rm FirefoxDeveloperEdition.tar.bz2 ; rm Firefox-Developer-Edition.desktop ;
 # Exit

--- a/personal/error.sh
+++ b/personal/error.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# ERROR message to display should CURL or WGET not be located or fail to download
+#
+# Error notice.
+printf -- '%s\n' "" "" "" " I am sorry. I cannot download from Mozilla." \
+  " It is remotely possible CURL or WGET is not available on your computer." \
+  " It is also possible your internet connection failed." \
+  " Please verify that either CURL or WGET is installed (either will work)." \
+  " If one of them is installed, please check your internet connection." \
+  " Or please contact your system administator for assistance." \
+  " " " " \
+  " I am now exiting the install... Nothing has changed on your computer." "" ""
+# error exit.
+exit 1

--- a/personal/extended.sh
+++ b/personal/extended.sh
@@ -2,8 +2,10 @@
 #
 # Firefox ESR (Extended Support Release) - personal - silent install
 #
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
 # Download
-wget -O FirefoxESR.tar.bz2 "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64";
+wget -L -O "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" || /.error.sh ;
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /home/$USER/Mozilla ;
 # Path where to be installed.
@@ -13,7 +15,7 @@ tar xjf FirefoxESR.tar.bz2 -C /home/$USER/Mozilla/firefox-esr/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /home/$USER/Mozilla/firefox-esr/firefox/ ;
 # Create icon script using echo command
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox ESR
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب
@@ -334,7 +336,7 @@ for destdir in /home/$USER/Desktop/; do
     cp Firefox-ESR.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-ESR.desktop"
 done
-echo -n;
+printf "\n";
 # Removes the temporary files no longer needed.
 rm FirefoxESR.tar.bz2 ; rm Firefox-ESR.desktop ;
 # Exit

--- a/personal/firefox.sh
+++ b/personal/firefox.sh
@@ -5,7 +5,7 @@
 # Make error.sh exactable so it can execut if needed.
 chmod +x ./error.sh;
 # Download.
-wget -L -O "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" || /.error.sh ;
+wget -L -O "FirefoxStable.tar.bz2" "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxStable.tar.bz2" "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64" || /.error.sh ;
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /home/$USER/Mozilla ;
 # Extracts to install path

--- a/personal/firefox.sh
+++ b/personal/firefox.sh
@@ -2,8 +2,10 @@
 #
 # Firefox (current stable edition) - personal - silent install
 #
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
 # Download.
-wget -O FirefoxStable.tar.bz2 "https://download.mozilla.org/?product=firefox-latest-ssl&os=linux64";
+wget -L -O "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxESR.tar.bz2" "https://download.mozilla.org/?product=firefox-esr-latest-ssl&os=linux64" || /.error.sh ;
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /home/$USER/Mozilla ;
 # Extracts to install path
@@ -11,7 +13,7 @@ tar xjf FirefoxStable.tar.bz2 -C /home/$USER/Mozilla ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /home/$USER/Mozilla/firefox/ ;
 # Create icon script using echo command
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Mozilla Firefox
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب
@@ -332,7 +334,7 @@ for destdir in /home/$USER/Desktop/; do
     cp Mozilla-Firefox.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Mozilla-Firefox.desktop"
 done
-echo -n;
+printf "\n";
 # Removes the temporary files no longer needed.
 rm FirefoxStable.tar.bz2 ; rm Mozilla-Firefox.desktop ;
 # Exit

--- a/personal/nightly.sh
+++ b/personal/nightly.sh
@@ -2,8 +2,10 @@
 #
 # Firefox Nightly - personal - silent install
 #
+# Make error.sh exactable so it can execut if needed.
+chmod +x ./error.sh;
 # Download.
-wget -O FirefoxNightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64";
+wget -L -O "FirefoxNightly.tar.bz2" "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64" >/dev/null || curl -L -o "FirefoxNightly.tar.bz2" "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64" || /.error.sh ;
 # Checks if distro has default opt path and if not found adds opt with default permissions.
 mkdir -p -m 755 /home/$USER/Mozilla ;
 # Path where to be installed.
@@ -13,7 +15,7 @@ tar xjf FirefoxNightly.tar.bz2 -C /home/$USER/Mozilla/firefox-nightly/ ;
 # Required permissions needed for Mozilla Firefox automatic update feature to work.
 chmod -R 757 /home/$USER/Mozilla/firefox-nightly/firefox/ ;
 # Create icon script using echo command
-echo "[Desktop Entry]
+printf "[Desktop Entry]
 Name=Firefox Nightly
 GenericName=Web Browser
 GenericName[ar]=متصفح وِب
@@ -334,7 +336,7 @@ for destdir in /home/$USER/Desktop/; do
     cp Firefox-Nightly.desktop "$destdir" &&
     chown --reference="$destdir" "$destdir/Firefox-Nightly.desktop"
 done
-echo -n;
+printf "\n";
 # Removes the temporary files no longer needed.
 rm FirefoxNightly.tar.bz2 ; rm Firefox-Nightly.desktop ;
 # Exit


### PR DESCRIPTION
**CURL support added** (for download during setup)

I was surprised to learn that "WGET" is not usually included in most distributions. My distribution of choice is often openSUSE or Debian and alike. I even recall testing more than a dozen random distros from distowatch.com, but they included "WGET." In short, I was living in a bubble. -- The script now will search for "WGET" and "CURL."  A friendly error message will display if neither is available.

**PRINTF is now the norm.** (replaces echo in all files)

Additionally, this release also replaces "echo" with "printf." Much to my surprise, I learned echo is not universal depending on distro and shell. It has been part of my driving goal to make the script as universally compatible as possible.  Using "prinf" further along that objective.

PURGE **option** added. (for uninstall)

In this release, I add a "purge" option for those who want a fresh, clean start. It includes a special caution notice outlining that this will purge all the cache and configuration files for all copies of Mozilla Firefox on your computer. This is ideal for developers or anyone else needing a clean profile and a fresh start.  I made this option a double-digit command so no one could mistakenly press a single number by mistake. I picked 66 for obvious reasons and found it fitting. --- Can anyone tell that I am a Star Wars fan? 

